### PR TITLE
Requesting a line clear beyond the written length of a terminal line causes NegativeArraySizeException

### DIFF
--- a/terminal/src/com/jediterm/terminal/model/TerminalLine.java
+++ b/terminal/src/com/jediterm/terminal/model/TerminalLine.java
@@ -228,7 +228,7 @@ public class TerminalLine {
 
   public synchronized void clearArea(int leftX, int rightX, @NotNull TextStyle style) {
     if (rightX == -1) {
-      rightX = myTextEntries.length();
+      rightX = Math.max(myTextEntries.length(), leftX);
     }
     writeCharacters(leftX, style, new CharBuffer(
             rightX >= myTextEntries.length() ? CharUtils.NUL_CHAR : CharUtils.EMPTY_CHAR,


### PR DESCRIPTION
The following command works in most (all?) terminals except Jedi, where it crashes:

printf '\033[1;100H\033[0KTEST\033[2;1H\033[0K'

What it does is move quite far to the right in the first line, where typically nothing has been written yet (test case will fail otherwise / crash will not happen), clears beyond that point, writes "TEST", moves to the second line, and clears everything there. The shell then gets to write its prompt on line 2.

In a working terminal this should result in the word "TEST" being written at the 100th position of the 1st line, or just the letter "T" at the right if the terminal width is too small.